### PR TITLE
ci: Automate workspace version bump to zk-circuits-v0.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -839,7 +839,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voting-circuit"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "qp-plonky2",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "wormhole-aggregator"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "wormhole-circuit"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "wormhole-prover"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "wormhole-verifier"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "zk-circuits-common"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "qp-plonky2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ edition = "2021"
 keywords = ["circuits", "plonky2", "wormhole", "zk"]
 license = "MIT"
 repository = "https://github.com/aletheia-labs/qp-zk-circuits-rm"
-version = "0.1.0"
+version = "0.0.1"
 
 [workspace.lints.clippy]
 uninlined_format_args = "allow"

--- a/voting/Cargo.toml
+++ b/voting/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2 = { workspace = true }
-zk-circuits-common = { path = "../common" }
+zk-circuits-common = { version = "0.0.1", path = "../common" }
 
 [features]
 default = ["std"]

--- a/wormhole/circuit/Cargo.toml
+++ b/wormhole/circuit/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 anyhow = { workspace = true }
 hex = { workspace = true, features = ["alloc"] }
 qp-plonky2 = { workspace = true }
-zk-circuits-common = { path = "../../common", default-features = false }
+zk-circuits-common = { version = "0.0.1", path = "../../common", default-features = false }
 
 [features]
 default = ["std"]

--- a/wormhole/prover/Cargo.toml
+++ b/wormhole/prover/Cargo.toml
@@ -9,8 +9,8 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2 = { workspace = true }
-wormhole-circuit = { path = "../circuit" }
-zk-circuits-common = { path = "../../common" }
+wormhole-circuit = { version = "0.0.1", path = "../circuit" }
+zk-circuits-common = { version = "0.0.1", path = "../../common" }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/wormhole/verifier/Cargo.toml
+++ b/wormhole/verifier/Cargo.toml
@@ -9,8 +9,8 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2 = { workspace = true, default-features = false }
-wormhole-circuit = { path = "../circuit", default-features = false }
-zk-circuits-common = { path = "../../common", default-features = false }
+wormhole-circuit = { version = "0.0.1", path = "../circuit", default-features = false }
+zk-circuits-common = { version = "0.0.1", path = "../../common", default-features = false }
 
 [dev-dependencies]
 criterion = { workspace = true }


### PR DESCRIPTION
Automated workspace version bump for release zk-circuits-v0.0.1.

https://github.com/aletheia-labs/qp-zk-circuits-rm/actions/runs/17573940431

Triggered by workflow run: patch

Type: 