### PR TITLE
ci: Automate workspace version bump to zk-circuits-v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "al-voting-circuit"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "al-zk-circuits-common",
  "anyhow",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "al-wormhole-aggregator"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "al-wormhole-circuit",
  "al-wormhole-prover",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "al-wormhole-circuit"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "al-zk-circuits-common",
  "anyhow",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "al-wormhole-circuit-builder"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "al-wormhole-circuit",
  "al-zk-circuits-common",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "al-wormhole-prover"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "al-wormhole-circuit",
  "al-zk-circuits-common",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "al-wormhole-verifier"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "al-wormhole-circuit",
  "al-wormhole-prover",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "al-zk-circuits-common"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "qp-plonky2",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "test-helpers"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "al-wormhole-circuit",
  "al-zk-circuits-common",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "al-wormhole-aggregator",
  "al-wormhole-circuit",
@@ -1096,7 +1096,7 @@ checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "wormhole-example"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "al-wormhole-circuit",
  "al-wormhole-prover",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ edition = "2021"
 keywords = ["circuits", "plonky2", "wormhole", "zk"]
 license = "MIT"
 repository = "https://github.com/aletheia-labs/qp-zk-circuits-rm"
-version = "0.0.2"
+version = "0.0.3"
 
 [workspace.lints.clippy]
 uninlined_format_args = "allow"

--- a/voting/Cargo.toml
+++ b/voting/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2 = { workspace = true }
-zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.2", path = "../common" }
+zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.3", path = "../common" }
 
 [features]
 default = ["std"]

--- a/wormhole/aggregator/Cargo.toml
+++ b/wormhole/aggregator/Cargo.toml
@@ -11,10 +11,10 @@ anyhow = { workspace = true }
 qp-plonky2 = { workspace = true }
 rayon = { version = "1.10.0", optional = true }
 test-helpers = { path = "../tests/test-helpers", default-features = false }
-wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.2", path = "../circuit", default-features = false }
-wormhole-prover = { package = "al-wormhole-prover", version = "0.0.2", path = "../prover", default-features = false }
-wormhole-verifier = { package = "al-wormhole-verifier", version = "0.0.2", path = "../verifier", default-features = false }
-zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.2", path = "../../common" }
+wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.3", path = "../circuit", default-features = false }
+wormhole-prover = { package = "al-wormhole-prover", version = "0.0.3", path = "../prover", default-features = false }
+wormhole-verifier = { package = "al-wormhole-verifier", version = "0.0.3", path = "../verifier", default-features = false }
+zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.3", path = "../../common" }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/wormhole/circuit-builder/Cargo.toml
+++ b/wormhole/circuit-builder/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 qp-plonky2 = { workspace = true, features = ["default"] }
-wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.2", path = "../circuit", default-features = false, features = [
+wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.3", path = "../circuit", default-features = false, features = [
 	"std",
 ] }
-zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.2", path = "../../common" }
+zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.3", path = "../../common" }

--- a/wormhole/circuit/Cargo.toml
+++ b/wormhole/circuit/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 anyhow = { workspace = true }
 hex = { workspace = true, features = ["alloc"] }
 qp-plonky2 = { workspace = true }
-zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.2", path = "../../common", default-features = false }
+zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.3", path = "../../common", default-features = false }
 
 [features]
 default = ["std"]

--- a/wormhole/example/Cargo.toml
+++ b/wormhole/example/Cargo.toml
@@ -8,8 +8,8 @@ version.workspace = true
 anyhow = { workspace = true, features = ["std"] }
 hex = { workspace = true, features = ["alloc"] }
 qp-plonky2 = { workspace = true, features = ["default"] }
-wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.2", path = "../circuit", default-features = false, features = [
+wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.3", path = "../circuit", default-features = false, features = [
 	"std",
 ] }
-wormhole-prover = { package = "al-wormhole-prover", version = "0.0.2", path = "../prover", default-features = false }
-zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.2", path = "../../common" }
+wormhole-prover = { package = "al-wormhole-prover", version = "0.0.3", path = "../prover", default-features = false }
+zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.3", path = "../../common" }

--- a/wormhole/prover/Cargo.toml
+++ b/wormhole/prover/Cargo.toml
@@ -9,8 +9,8 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2 = { workspace = true }
-wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.2", path = "../circuit" }
-zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.2", path = "../../common" }
+wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.3", path = "../circuit" }
+zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.3", path = "../../common" }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/wormhole/tests/Cargo.toml
+++ b/wormhole/tests/Cargo.toml
@@ -19,11 +19,11 @@ rand = { version = "0.9.1", default-features = false, features = [
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 test-helpers = { path = "./test-helpers" }
-wormhole-aggregator = { package = "al-wormhole-aggregator", version = "0.0.2", path = "../aggregator" }
-wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.2", path = "../circuit", default-features = true }
-wormhole-prover = { package = "al-wormhole-prover", version = "0.0.2", path = "../prover", default-features = true }
-wormhole-verifier = { package = "al-wormhole-verifier", version = "0.0.2", path = "../verifier", default-features = true }
-zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.2", path = "../../common" }
+wormhole-aggregator = { package = "al-wormhole-aggregator", version = "0.0.3", path = "../aggregator" }
+wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.3", path = "../circuit", default-features = true }
+wormhole-prover = { package = "al-wormhole-prover", version = "0.0.3", path = "../prover", default-features = true }
+wormhole-verifier = { package = "al-wormhole-verifier", version = "0.0.3", path = "../verifier", default-features = true }
+zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.3", path = "../../common" }
 
 [lints]
 workspace = true

--- a/wormhole/tests/test-helpers/Cargo.toml
+++ b/wormhole/tests/test-helpers/Cargo.toml
@@ -6,5 +6,5 @@ version.workspace = true
 [dependencies]
 hex = { workspace = true }
 qp-plonky2 = { workspace = true, default-features = true }
-wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.2", path = "../../circuit" }
-zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.2", path = "../../../common" }
+wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.3", path = "../../circuit" }
+zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.3", path = "../../../common" }

--- a/wormhole/verifier/Cargo.toml
+++ b/wormhole/verifier/Cargo.toml
@@ -9,8 +9,8 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2 = { workspace = true, default-features = false }
-wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.2", path = "../circuit", default-features = false }
-zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.2", path = "../../common", default-features = false }
+wormhole-circuit = { package = "al-wormhole-circuit", version = "0.0.3", path = "../circuit", default-features = false }
+zk-circuits-common = { package = "al-zk-circuits-common", version = "0.0.3", path = "../../common", default-features = false }
 
 [dev-dependencies]
 al-wormhole-prover = { path = "../prover" }


### PR DESCRIPTION
Automated workspace version bump for release zk-circuits-v0.0.3.

https://github.com/aletheia-labs/qp-zk-circuits-rm/actions/runs/17602708253

Triggered by workflow run: patch

Type: 